### PR TITLE
Bugfixes for browser-core pipelines

### DIFF
--- a/vars/helpers.groovy
+++ b/vars/helpers.groovy
@@ -42,9 +42,9 @@ def getIp() {
     sh(
         returnStdout: true,
         script: '''#!/bin/bash
-            /sbin/ifconfig eth0 | grep "inet addr:" | cut -d: -f2 | awk \'{ print $1}\'
+            curl http://169.254.169.254/latest/meta-data/local-ipv4
         '''
-     ).trim()
+    ).trim()
 }
 
 return this

--- a/vars/xunit.groovy
+++ b/vars/xunit.groovy
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
-def parse(reportPath) {
-    def result = sh(returnStdout: true, script: "xmllint --xpath '//testsuite/@*' ${reportPath}").trim()
+@NonCPS
+def _parse(result) {
     def lstResult = result =~ /([^=]+)="([^"]+)"[\s]*/
 
     def summary = [:]
@@ -10,7 +10,13 @@ def parse(reportPath) {
         summary[lstResult[i][1]] = lstResult[i][2]
       }
     }
+    lstResult = null
     return summary
+}
+
+def parse(reportPath) {
+    def result = sh(returnStdout: true, script: "xmllint --xpath '//testsuite/@*' ${reportPath}").trim()
+    return _parse(result)
 }
 
 // source: https://issues.jenkins-ci.org/browse/JENKINS-27395?focusedCommentId=256459&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-256459

--- a/vars/xunit.groovy
+++ b/vars/xunit.groovy
@@ -7,7 +7,10 @@ def _parse(result) {
     def summary = [:]
     if (lstResult.hasGroup()) {
       for (int i=0; i<lstResult.size(); i++) {
-        summary[lstResult[i][1]] = lstResult[i][2]
+        def res = lstResult[i]
+        if (res.size() >= 2) {
+          summary[res[1]] = res[2]
+        }
       }
     }
     lstResult = null


### PR DESCRIPTION
* `helpers.getIP` uses aws api instead of parsing `ifconfig` output
* `xunit.parse` is split to encapsulate `@NonCPS` parts that were throwing errors in production